### PR TITLE
Add color values for item rarities "Unknown" and "Varies"

### DIFF
--- a/DNDBeyond site dark.user.css
+++ b/DNDBeyond site dark.user.css
@@ -2006,6 +2006,14 @@ div#site{
     }
 
 
+	.listing .info .row.item-name .name .varies,
+	.varies {
+		color: #AAAAAA !important;
+	}
+	.listing .info .row.item-name .name .unknown-rarity,
+	.unknown-rarity {
+		color: #666666 !important;
+	}
 	.listing .info .row.item-name .name .very-rare,
 	.very-rare {
 		color: #9810E0 !important;


### PR DESCRIPTION
On D&D Beyond magic item listing pages (https://www.dndbeyond.com/homebrew/magic-items), items with rarity values of "Unknown Rarity" and "Varies" had unreadable black text on a black background.  This change adds the necessary lines to change the foreground color of those text elements so that they become visible again.  I used two different shades of grey, since it was not obvious to me what would best fit the existing color scheme.

Please take this as a mere suggestion, and thank you for making the D&D Beyond website bearable to look at!